### PR TITLE
Load api_config.js.

### DIFF
--- a/fs/init.js
+++ b/fs/init.js
@@ -2,6 +2,7 @@ load('api_arduino_bme280.js');
 load('api_gpio.js');
 load('api_blynk.js');
 load('api_sys.js');
+load('api_config.js');
 
 // Sensors address
 let sens_addr = Cfg.get('i2c.address') | 0x77;


### PR DESCRIPTION
This did not work for me without explicitly loading the config API:

```
[Nov 15 22:42:40.284] mgos_init            Init done, RAM: 52408 total, 43892 free, 43776 min free
[Nov 15 22:42:40.689]   at init.js:7
[Nov 15 22:42:40.691] MJS error: [Cfg] is not defined
```